### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ pod 'JZLocationConverter'
 
 WGS-84世界标准坐标、GCJ-02中国国测局(火星坐标)、BD-09百度坐标系转换
 目前有:
-##WGS-84  -> GCJ-02 
+## WGS-84  -> GCJ-02 
 ### 此接口当输入坐标为中国大陆以外时，仍旧返回WGS-84坐标
     + (CLLocationCoordinate2D)wgs84ToGcj02:(CLLocationCoordinate2D)location;
-##GCJ-02  -> WGS-84
+## GCJ-02  -> WGS-84
 ### 此接口有1-2米左右的误差，需要精确的场景慎用
     + (CLLocationCoordinate2D)gcj02ToWgs84:(CLLocationCoordinate2D)location;
-##WGS-84  -> BD-09
+## WGS-84  -> BD-09
     + (CLLocationCoordinate2D)wgs84ToBd09:(CLLocationCoordinate2D)location;
-##BD-09     -> WGS-84
+## BD-09     -> WGS-84
     + (CLLocationCoordinate2D)bd09ToWgs84:(CLLocationCoordinate2D)location;
-##GCJ-02   -> BD-09
+## GCJ-02   -> BD-09
     + (CLLocationCoordinate2D)gcj02ToBd09:(CLLocationCoordinate2D)location;
-##BD-09     -> GCJ-02
+## BD-09     -> GCJ-02
 ### 此接口有1-2米左右的误差，需要精确的场景慎用
     + (CLLocationCoordinate2D)bd09ToGcj02:(CLLocationCoordinate2D)location;


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
